### PR TITLE
Fixed. `plant_erd sqlite3` doesn't work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,15 +40,15 @@ jobs:
           - os: darwin
             runner: macos-latest
           - os: freebsd
-            runner: ubuntu-latest
+            runner: ubuntu-18.04
           - os: linux
-            runner: ubuntu-latest
+            runner: ubuntu-18.04
           - os: netbsd
-            runner: ubuntu-latest
+            runner: ubuntu-18.04
           - os: openbsd
-            runner: ubuntu-latest
+            runner: ubuntu-18.04
           - os: windows
-            runner: ubuntu-latest
+            runner: ubuntu-18.04
         exclude:
           - os: darwin
             arch: arm

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-oracle: bin/plant_erd-oracle
 
 .PHONY: gox-plant_erd
 gox-plant_erd:
-	CGO_ENABLED=0 gox -osarch="$${GOX_OSARCH}" -ldflags=$(LDFLAGS) -output="bin/$(NAME)_{{.OS}}_{{.Arch}}" $(PACKAGE)/cmd/plant_erd
+	gox -osarch="$${GOX_OSARCH}" -ldflags=$(LDFLAGS) -output="bin/$(NAME)_{{.OS}}_{{.Arch}}" $(PACKAGE)/cmd/plant_erd
 
 .PHONY: gox-plant_erd-oracle
 gox-plant_erd-oracle:


### PR DESCRIPTION
This is regression of #153 

Close #155

# TODO
* [x] `plant_erd_linux_amd64  sqlite3`  works on Ubuntu 18.04
* [x] `plant_erd_linux_amd64  sqlite3`  works on Ubuntu 20.04
* [x] `plant_erd_darwin_amd64 sqlite3` works on Mac (Intel)
* [x] `plant_erd_darwin_arm64 sqlite3` works on Mac (M1)
  * `plant_erd_darwin_arm64 sqlite3` doesn't works on Mac (M1), but `plant_erd_darwin_amd64 sqlite3` works on Mac (M1) 😇 