### PR TITLE
Exclude views on MySQL command

### DIFF
--- a/adapter/mysql/adapter.go
+++ b/adapter/mysql/adapter.go
@@ -2,12 +2,13 @@ package mysql
 
 import (
 	"fmt"
-	"github.com/go-sql-driver/mysql"
-	"github.com/jmoiron/sqlx"
-	"github.com/sue445/plant_erd/db"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+	"github.com/sue445/plant_erd/db"
 )
 
 // Adapter represents MySQL adapter
@@ -42,7 +43,7 @@ func rowInt(row map[string]interface{}, columnName string) int {
 // GetAllTableNames returns all table names in database
 func (a *Adapter) GetAllTableNames() ([]string, error) {
 	var rows []informationSchemaTables
-	err := a.db.Select(&rows, "SELECT table_name AS table_name FROM information_schema.tables WHERE table_schema=database() ORDER BY table_name")
+	err := a.db.Select(&rows, "SELECT table_name AS table_name FROM information_schema.tables WHERE table_schema=database() AND table_type = 'BASE TABLE' ORDER BY table_name")
 
 	if err != nil {
 		return []string{}, err

--- a/adapter/mysql/adapter_test.go
+++ b/adapter/mysql/adapter_test.go
@@ -2,17 +2,18 @@ package mysql
 
 import (
 	"fmt"
-	"github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/assert"
-	"github.com/sue445/plant_erd/db"
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/sue445/plant_erd/db"
 )
 
 func TestMain(m *testing.M) {
 	if os.Getenv("MYSQL_HOST") == "" || os.Getenv("MYSQL_PORT") == "" || os.Getenv("MYSQL_USER") == "" || os.Getenv("MYSQL_DATABASE") == "" {
-		println("adapter/mysql test is skipped because MYSQL_HOST, MYSQL_PORT and MYSQL_USER not all set")
+		println("adapter/mysql test is skipped because MYSQL_HOST, MYSQL_PORT, MYSQL_USER and MYSQL_DATABASE not all set")
 		return
 	}
 
@@ -45,7 +46,7 @@ func TestAdapter_GetAllTableNames(t *testing.T) {
 	withDatabase(func(a *Adapter) {
 		a.db.MustExec(`
 			CREATE TABLE users (
-				id   int not null primary key, 
+				id   int not null primary key,
 				name varchar(191)
 		);`)
 		defer func() {
@@ -54,12 +55,18 @@ func TestAdapter_GetAllTableNames(t *testing.T) {
 
 		a.db.MustExec(`
 			CREATE TABLE articles (
-				id      int not null primary key, 
-				user_id int not null, 
+				id      int not null primary key,
+				user_id int not null,
 				FOREIGN KEY fk_users (user_id) REFERENCES users(id)
 		);`)
+
 		defer func() {
 			a.db.MustExec("DROP TABLE articles;")
+		}()
+
+		a.db.MustExec("CREATE VIEW user_names AS SELECT name FROM users;")
+		defer func() {
+			a.db.MustExec("DROP VIEW user_names;")
 		}()
 
 		tables, err := a.GetAllTableNames()
@@ -74,7 +81,7 @@ func TestAdapter_GetTable(t *testing.T) {
 	withDatabase(func(a *Adapter) {
 		a.db.MustExec(`
 			CREATE TABLE users (
-				id   int not null primary key, 
+				id   int not null primary key,
 				name varchar(191)
 		);`)
 		defer func() {
@@ -83,8 +90,8 @@ func TestAdapter_GetTable(t *testing.T) {
 
 		a.db.MustExec(`
 			CREATE TABLE articles (
-				id      int not null primary key, 
-				user_id int not null, 
+				id      int not null primary key,
+				user_id int not null,
 				FOREIGN KEY fk_users (user_id) REFERENCES users(id)
 		);`)
 		defer func() {

--- a/adapter/oracle/adapter_test.go
+++ b/adapter/oracle/adapter_test.go
@@ -1,16 +1,17 @@
 package oracle
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/sue445/plant_erd/db"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/sue445/plant_erd/db"
 )
 
 func TestMain(m *testing.M) {
 	if os.Getenv("ORACLE_HOST") == "" || os.Getenv("ORACLE_PORT") == "" || os.Getenv("ORACLE_USER") == "" || os.Getenv("ORACLE_SERVICE") == "" {
-		println("adapter/oracle test is skipped because ORACLE_HOST, ORACLE_PORT and ORACLE_USER and ORACLE_SERVICE not all set")
+		println("adapter/oracle test is skipped because ORACLE_HOST, ORACLE_PORT, ORACLE_USER and ORACLE_SERVICE not all set")
 		return
 	}
 
@@ -43,7 +44,7 @@ func TestAdapter_GetAllTableNames(t *testing.T) {
 	withDatabase(func(a *Adapter) {
 		a.db.MustExec(`
 			CREATE TABLE users (
-				id   integer not null primary key, 
+				id   integer not null primary key,
 				name varchar(191)
 		)`)
 		defer func() {
@@ -52,12 +53,17 @@ func TestAdapter_GetAllTableNames(t *testing.T) {
 
 		a.db.MustExec(`
 			CREATE TABLE articles (
-				id      integer not null primary key, 
-				user_id integer not null, 
+				id      integer not null primary key,
+				user_id integer not null,
 				FOREIGN KEY (user_id) REFERENCES users(id)
 		)`)
 		defer func() {
 			a.db.MustExec("DROP TABLE articles")
+		}()
+
+		a.db.MustExec("CREATE VIEW user_names AS SELECT name FROM users")
+		defer func() {
+			a.db.MustExec("DROP VIEW user_names")
 		}()
 
 		tables, err := a.GetAllTableNames()
@@ -82,8 +88,8 @@ func TestAdapter_GetTable(t *testing.T) {
 
 		a.db.MustExec(`
 			CREATE TABLE articles (
-				id      integer not null primary key, 
-				user_id integer not null, 
+				id      integer not null primary key,
+				user_id integer not null,
 				FOREIGN KEY(user_id) REFERENCES users(id)
 		)`)
 		defer func() {

--- a/adapter/postgresql/adapter_test.go
+++ b/adapter/postgresql/adapter_test.go
@@ -1,16 +1,17 @@
 package postgresql
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/sue445/plant_erd/db"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/sue445/plant_erd/db"
 )
 
 func TestMain(m *testing.M) {
 	if os.Getenv("POSTGRES_HOST") == "" || os.Getenv("POSTGRES_PORT") == "" || os.Getenv("POSTGRES_USER") == "" || os.Getenv("POSTGRES_DATABASE") == "" {
-		println("adapter/postgresql test is skipped because POSTGRES_HOST, POSTGRES_PORT and POSTGRES_USER not all set")
+		println("adapter/postgresql test is skipped because POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER and POSTGRES_DATABASE not all set")
 		return
 	}
 
@@ -43,7 +44,7 @@ func TestAdapter_GetAllTableNames(t *testing.T) {
 	withDatabase(func(a *Adapter) {
 		a.db.MustExec(`
 			CREATE TABLE users (
-				id   integer not null primary key, 
+				id   integer not null primary key,
 				name varchar(191)
 		);`)
 		defer func() {
@@ -52,12 +53,17 @@ func TestAdapter_GetAllTableNames(t *testing.T) {
 
 		a.db.MustExec(`
 			CREATE TABLE articles (
-				id      integer not null primary key, 
-				user_id integer not null, 
+				id      integer not null primary key,
+				user_id integer not null,
 				FOREIGN KEY (user_id) REFERENCES users(id)
 		);`)
 		defer func() {
 			a.db.MustExec("DROP TABLE articles;")
+		}()
+
+		a.db.MustExec("CREATE VIEW user_names AS SELECT name FROM users;")
+		defer func() {
+			a.db.MustExec("DROP VIEW user_names;")
 		}()
 
 		tables, err := a.GetAllTableNames()
@@ -81,8 +87,8 @@ func TestAdapter_GetTable(t *testing.T) {
 
 		a.db.MustExec(`
 			CREATE TABLE articles (
-				id      integer not null primary key, 
-				user_id integer not null, 
+				id      integer not null primary key,
+				user_id integer not null,
 				FOREIGN KEY(user_id) REFERENCES users(id)
 		);`)
 		defer func() {

--- a/adapter/sqlite3/adapter_test.go
+++ b/adapter/sqlite3/adapter_test.go
@@ -1,9 +1,10 @@
 package sqlite3
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/sue445/plant_erd/db"
-	"testing"
 )
 
 func withDatabase(callback func(*Adapter)) {
@@ -30,10 +31,12 @@ func TestAdapter_GetAllTableNames(t *testing.T) {
 
 		a.DB.MustExec(`
 			CREATE TABLE articles (
-				id      integer not null primary key, 
-				user_id integer not null, 
+				id      integer not null primary key,
+				user_id integer not null,
 				FOREIGN KEY(user_id) REFERENCES users(id)
 		);`)
+
+		a.DB.MustExec("CREATE VIEW user_names AS SELECT name FROM users;")
 
 		tables, err := a.GetAllTableNames()
 
@@ -53,8 +56,8 @@ func TestAdapter_GetTable(t *testing.T) {
 
 		a.DB.MustExec(`
 			CREATE TABLE articles (
-				id      integer not null primary key, 
-				user_id integer not null, 
+				id      integer not null primary key,
+				user_id integer not null,
 				FOREIGN KEY(user_id) REFERENCES users(id)
 		);`)
 		a.DB.MustExec("CREATE INDEX index_user_id_on_articles ON articles(user_id)")


### PR DESCRIPTION
Close #156 

To exclude views from the output of `plant_erd mysql`, this PR adds `WHERE` clause which checks `table_type` column to the `SELECT` query in `mysql.Adapter.GetAllTableNames`.
(The value of `table_type` column is  either `"BASE TABLE"` or `"VIEW"`)

In addition, this modify test case of each `Adapter.GetAllTableNames` to check excluding views.