### PR TITLE
Fix mermaid attribute error and display "not null"

### DIFF
--- a/db/column.go
+++ b/db/column.go
@@ -1,6 +1,9 @@
 package db
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Column represents column info
 type Column struct {
@@ -25,5 +28,13 @@ func (c *Column) ToErd() string {
 
 // ToMermaid returns Mermaid formatted column
 func (c *Column) ToMermaid() string {
-	return fmt.Sprintf("%s %s", c.Type, c.Name)
+	mermaidType := c.Type
+
+	// mermaid cannot display Type Column "()" and "unsigned"
+	mermaidType = strings.Replace(mermaidType, "(", "[", -1)
+	mermaidType = strings.Replace(mermaidType, ")", "]", -1)
+
+	mermaidType = strings.Replace(mermaidType, " ", "_", -1)
+
+	return fmt.Sprintf("%s %s", mermaidType, c.Name)
 }

--- a/db/column.go
+++ b/db/column.go
@@ -31,8 +31,8 @@ func (c *Column) ToMermaid() string {
 	mermaidType := c.Type
 
 	// mermaid cannot display Type Column "()" and "unsigned"
-	mermaidType = strings.Replace(mermaidType, "(", "[", -1)
-	mermaidType = strings.Replace(mermaidType, ")", "]", -1)
+	mermaidType = strings.Replace(mermaidType, "(", "_", -1)
+	mermaidType = strings.Replace(mermaidType, ")", "", -1)
 
 	mermaidType = strings.Replace(mermaidType, " ", "_", -1)
 

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -194,7 +194,7 @@ func TestSchema_ToMermaid(t *testing.T) {
 			want: `erDiagram
 
 articles {
-  integer[10]_unsigned id PK "not null"
+  integer_10_unsigned id PK "not null"
   integer user_id FK "not null"
 }
 
@@ -240,7 +240,7 @@ users ||--o{ articles : owns`,
 			want: `erDiagram
 
 articles {
-  integer[10]_unsigned id PK "not null"
+  integer_10_unsigned id PK "not null"
   integer user_id FK "not null"
 }`,
 		},

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -1,8 +1,9 @@
 package db
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSchema_ToErd(t *testing.T) {
@@ -152,7 +153,7 @@ func TestSchema_ToMermaid(t *testing.T) {
 						Columns: []*Column{
 							{
 								Name:       "id",
-								Type:       "integer",
+								Type:       "integer(10) unsigned",
 								NotNull:    true,
 								PrimaryKey: true,
 							},
@@ -193,12 +194,12 @@ func TestSchema_ToMermaid(t *testing.T) {
 			want: `erDiagram
 
 articles {
-  integer id PK
-  integer user_id FK
+  integer[10]_unsigned id PK "not null"
+  integer user_id FK "not null"
 }
 
 users {
-  integer id PK
+  integer id PK "not null"
   text name
 }
 
@@ -213,7 +214,7 @@ users ||--o{ articles : owns`,
 						Columns: []*Column{
 							{
 								Name:       "id",
-								Type:       "integer",
+								Type:       "integer(10) unsigned",
 								NotNull:    true,
 								PrimaryKey: true,
 							},
@@ -239,8 +240,8 @@ users ||--o{ articles : owns`,
 			want: `erDiagram
 
 articles {
-  integer id PK
-  integer user_id FK
+  integer[10]_unsigned id PK "not null"
+  integer user_id FK "not null"
 }`,
 		},
 	}
@@ -262,7 +263,7 @@ func TestSchema_Subset(t *testing.T) {
 		Columns: []*Column{
 			{
 				Name:       "id",
-				Type:       "integer",
+				Type:       "integer(10) unsigned",
 				NotNull:    true,
 				PrimaryKey: true,
 			},
@@ -286,7 +287,7 @@ func TestSchema_Subset(t *testing.T) {
 		Columns: []*Column{
 			{
 				Name:       "id",
-				Type:       "integer",
+				Type:       "integer(10) unsigned",
 				NotNull:    true,
 				PrimaryKey: true,
 			},
@@ -310,7 +311,7 @@ func TestSchema_Subset(t *testing.T) {
 		Columns: []*Column{
 			{
 				Name:       "id",
-				Type:       "integer",
+				Type:       "integer(10) unsigned",
 				NotNull:    true,
 				PrimaryKey: true,
 			},
@@ -344,7 +345,7 @@ func TestSchema_Subset(t *testing.T) {
 		Columns: []*Column{
 			{
 				Name:       "id",
-				Type:       "integer",
+				Type:       "integer(10) unsigned",
 				NotNull:    true,
 				PrimaryKey: true,
 			},
@@ -378,7 +379,7 @@ func TestSchema_Subset(t *testing.T) {
 		Columns: []*Column{
 			{
 				Name:    "article_id",
-				Type:    "integer",
+				Type:    "integer(10) unsigned",
 				NotNull: true,
 			},
 			{

--- a/db/table.go
+++ b/db/table.go
@@ -87,6 +87,11 @@ func (t *Table) ToMermaid(showComment bool) string {
 		parts = append(parts, column.ToMermaid())
 
 		if showComment {
+			key := t.mermaidColumnKey(column)
+			if key != "" {
+				parts = append(parts, key)
+			}
+
 			comment := t.mermaidColumnComment(column)
 			if comment != "" {
 				parts = append(parts, comment)
@@ -101,7 +106,7 @@ func (t *Table) ToMermaid(showComment bool) string {
 	return strings.Join(lines, "\n")
 }
 
-func (t *Table) mermaidColumnComment(column *Column) string {
+func (t *Table) mermaidColumnKey(column *Column) string {
 	if column.PrimaryKey {
 		return "PK"
 	}
@@ -113,4 +118,16 @@ func (t *Table) mermaidColumnComment(column *Column) string {
 	}
 
 	return ""
+}
+
+func (t *Table) mermaidColumnComment(column *Column) string {
+	parts := []string{}
+	if column.NotNull {
+		parts = append(parts, "not null")
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("\"%s\"", strings.Join(parts, " "))
 }

--- a/db/table_test.go
+++ b/db/table_test.go
@@ -1,8 +1,9 @@
 package db
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTable_ToErd(t *testing.T) {
@@ -239,7 +240,7 @@ func TestTable_ToMermaid(t *testing.T) {
 				Columns: []*Column{
 					{
 						Name:       "id",
-						Type:       "integer",
+						Type:       "integer(10) unsigned",
 						NotNull:    true,
 						PrimaryKey: true,
 					},
@@ -265,8 +266,8 @@ func TestTable_ToMermaid(t *testing.T) {
 				showComment: true,
 			},
 			want: `articles {
-  integer id PK
-  integer user_id FK
+  integer[10]_unsigned id PK "not null"
+  integer user_id FK "not null"
   text title
 }`,
 		},
@@ -277,7 +278,7 @@ func TestTable_ToMermaid(t *testing.T) {
 				Columns: []*Column{
 					{
 						Name:       "id",
-						Type:       "integer",
+						Type:       "integer(10) unsigned",
 						NotNull:    true,
 						PrimaryKey: true,
 					},
@@ -303,7 +304,7 @@ func TestTable_ToMermaid(t *testing.T) {
 				showComment: false,
 			},
 			want: `articles {
-  integer id
+  integer[10]_unsigned id
   integer user_id
   text title
 }`,

--- a/db/table_test.go
+++ b/db/table_test.go
@@ -266,7 +266,7 @@ func TestTable_ToMermaid(t *testing.T) {
 				showComment: true,
 			},
 			want: `articles {
-  integer[10]_unsigned id PK "not null"
+  integer_10_unsigned id PK "not null"
   integer user_id FK "not null"
   text title
 }`,
@@ -304,7 +304,7 @@ func TestTable_ToMermaid(t *testing.T) {
 				showComment: false,
 			},
 			want: `articles {
-  integer[10]_unsigned id
+  integer_10_unsigned id
   integer user_id
   text title
 }`,


### PR DESCRIPTION
## Fix mermaid attribute error

- In mermaid, "(" and ")" are attibute word, the letters are changed  to "_"
  - ex. varchar(255) -> varchar_255
  - N.B. "[" and "]" are errors on GitHub 
- A syntax error was occurring due to a space that occurs in the unsigned type, so it was changed to an underscore.
  - ex. integer unsigned -> integer_unsigned

## Display "not null"

Required `--show-comment` option

ex. MySQL

```sql
Create TABLE example (
    id integer unsigned not null primary key,
    name varchar(255)
);
```

### before (error occurs)

```md
erDiagram

example {
  int unsigned id PK
  varchar(255) name
}
```

```mermaid
erDiagram

example {
  int unsigned id PK
  varchar(255) name
}
```

### after

```md
erDiagram

example {
  int_unsigned id PK "not null"
  varchar_255 name
}
```

```mermaid
erDiagram

example {
  int_unsigned id PK "not null"
  varchar_255 name
}
```

Thanks.