### PR TITLE
Fix for oracle open cursor and foreign key issue

### DIFF
--- a/adapter/oracle/adapter.go
+++ b/adapter/oracle/adapter.go
@@ -250,7 +250,7 @@ func (a *Adapter) getIndexColumns(indexName string) ([]string, error) {
 	var rows []allIndColumns
 	err = stmt.Select(&rows, indexName)
 	defer stmt.Close()
-	
+
 	if err != nil {
 		return nil, err
 	}

--- a/adapter/oracle/adapter.go
+++ b/adapter/oracle/adapter.go
@@ -77,6 +77,7 @@ func (a *Adapter) GetTable(tableName string) (*db.Table, error) {
 
 	var rows []allTabColumns
 	err = stmt.Select(&rows, tableName)
+	defer stmt.Close()
 
 	if err != nil {
 		return nil, err
@@ -104,7 +105,6 @@ func (a *Adapter) GetTable(tableName string) (*db.Table, error) {
 	}
 	table.Indexes = indexes
 
-	defer stmt.Close()
 	return &table, nil
 }
 
@@ -128,17 +128,18 @@ func (a *Adapter) getPrimaryKeyColumns(tableName string) (mapset.Set, error) {
 
 	var rows []primaryKeys
 	err = stmt.Select(&rows, tableName)
+	defer stmt.Close()
 
 	if err != nil {
 		return nil, err
 	}
+
 
 	columns := mapset.NewSet()
 	for _, row := range rows {
 		columns.Add(row.ColumnName)
 	}
 
-	defer stmt.Close()
 	return columns, nil
 }
 
@@ -170,6 +171,7 @@ func (a *Adapter) getForeignKeys(tableName string) ([]*db.ForeignKey, error) {
 
 	var rows []foreignKey
 	err = stmt.Select(&rows, tableName)
+	defer stmt.Close()
 
 	if err != nil {
 		return nil, err
@@ -186,7 +188,6 @@ func (a *Adapter) getForeignKeys(tableName string) ([]*db.ForeignKey, error) {
 		foreignKeys = append(foreignKeys, foreignKey)
 	}
 
-	defer stmt.Close()
 	return foreignKeys, nil
 }
 
@@ -213,10 +214,12 @@ func (a *Adapter) getIndexes(tableName string) ([]*db.Index, error) {
 
 	var rows []allIndexes
 	err = stmt.Select(&rows, tableName)
+	defer stmt.Close()
 
 	if err != nil {
 		return nil, err
 	}
+
 	var indexes []*db.Index
 	for _, row := range rows {
 		columns, err := a.getIndexColumns(row.IndexName)
@@ -231,7 +234,7 @@ func (a *Adapter) getIndexes(tableName string) ([]*db.Index, error) {
 		}
 		indexes = append(indexes, index)
 	}
-	defer stmt.Close()
+
 	return indexes, nil
 }
 
@@ -246,7 +249,8 @@ func (a *Adapter) getIndexColumns(indexName string) ([]string, error) {
 
 	var rows []allIndColumns
 	err = stmt.Select(&rows, indexName)
-
+	defer stmt.Close()
+	
 	if err != nil {
 		return nil, err
 	}
@@ -257,6 +261,5 @@ func (a *Adapter) getIndexColumns(indexName string) ([]string, error) {
 		columns = append(columns, row.ColumnName)
 	}
 
-    defer stmt.Close()
 	return columns, nil
 }

--- a/adapter/oracle/adapter.go
+++ b/adapter/oracle/adapter.go
@@ -134,7 +134,6 @@ func (a *Adapter) getPrimaryKeyColumns(tableName string) (mapset.Set, error) {
 		return nil, err
 	}
 
-
 	columns := mapset.NewSet()
 	for _, row := range rows {
 		columns.Add(row.ColumnName)
@@ -219,7 +218,6 @@ func (a *Adapter) getIndexes(tableName string) ([]*db.Index, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	var indexes []*db.Index
 	for _, row := range rows {
 		columns, err := a.getIndexColumns(row.IndexName)

--- a/adapter/oracle/adapter.go
+++ b/adapter/oracle/adapter.go
@@ -105,7 +105,6 @@ func (a *Adapter) GetTable(tableName string) (*db.Table, error) {
 	table.Indexes = indexes
 
 	defer stmt.Close()
-
 	return &table, nil
 }
 
@@ -140,7 +139,6 @@ func (a *Adapter) getPrimaryKeyColumns(tableName string) (mapset.Set, error) {
 	}
 
 	defer stmt.Close()
-
 	return columns, nil
 }
 
@@ -189,7 +187,6 @@ func (a *Adapter) getForeignKeys(tableName string) ([]*db.ForeignKey, error) {
 	}
 
 	defer stmt.Close()
-
 	return foreignKeys, nil
 }
 
@@ -235,7 +232,6 @@ func (a *Adapter) getIndexes(tableName string) ([]*db.Index, error) {
 		indexes = append(indexes, index)
 	}
 	defer stmt.Close()
-
 	return indexes, nil
 }
 
@@ -262,6 +258,5 @@ func (a *Adapter) getIndexColumns(indexName string) ([]string, error) {
 	}
 
     defer stmt.Close()
-	
 	return columns, nil
 }

--- a/adapter/oracle/adapter.go
+++ b/adapter/oracle/adapter.go
@@ -104,6 +104,8 @@ func (a *Adapter) GetTable(tableName string) (*db.Table, error) {
 	}
 	table.Indexes = indexes
 
+	defer stmt.Close()
+
 	return &table, nil
 }
 
@@ -136,6 +138,8 @@ func (a *Adapter) getPrimaryKeyColumns(tableName string) (mapset.Set, error) {
 	for _, row := range rows {
 		columns.Add(row.ColumnName)
 	}
+
+	defer stmt.Close()
 
 	return columns, nil
 }
@@ -184,6 +188,8 @@ func (a *Adapter) getForeignKeys(tableName string) ([]*db.ForeignKey, error) {
 		foreignKeys = append(foreignKeys, foreignKey)
 	}
 
+	defer stmt.Close()
+
 	return foreignKeys, nil
 }
 
@@ -228,6 +234,7 @@ func (a *Adapter) getIndexes(tableName string) ([]*db.Index, error) {
 		}
 		indexes = append(indexes, index)
 	}
+	defer stmt.Close()
 
 	return indexes, nil
 }
@@ -254,5 +261,7 @@ func (a *Adapter) getIndexColumns(indexName string) ([]string, error) {
 		columns = append(columns, row.ColumnName)
 	}
 
+    defer stmt.Close()
+	
 	return columns, nil
 }

--- a/db/schema.go
+++ b/db/schema.go
@@ -28,7 +28,7 @@ func (s *Schema) ToErd(showIndex bool) string {
 
 	for _, table := range s.Tables {
 		for _, foreignKey := range table.ForeignKeys {
-            toTable := strings.ToLower(foreignKey.ToTable)
+			toTable := strings.ToLower(foreignKey.ToTable)
 			if tableNames.Contains(toTable) {
 				lines = append(lines, fmt.Sprintf("%s }-- %s", table.Name, toTable))
 			}

--- a/db/schema.go
+++ b/db/schema.go
@@ -28,8 +28,9 @@ func (s *Schema) ToErd(showIndex bool) string {
 
 	for _, table := range s.Tables {
 		for _, foreignKey := range table.ForeignKeys {
-			if tableNames.Contains(foreignKey.ToTable) {
-				lines = append(lines, fmt.Sprintf("%s }-- %s", table.Name, foreignKey.ToTable))
+            toTable := strings.ToLower(foreignKey.ToTable)
+			if tableNames.Contains(toTable) {
+				lines = append(lines, fmt.Sprintf("%s }-- %s", table.Name, toTable))
 			}
 		}
 	}

--- a/db/schema.go
+++ b/db/schema.go
@@ -52,8 +52,9 @@ func (s *Schema) ToMermaid(showComment bool) string {
 
 	for _, table := range s.Tables {
 		for _, foreignKey := range table.ForeignKeys {
-			if tableNames.Contains(foreignKey.ToTable) {
-				lines = append(lines, fmt.Sprintf("%s ||--o{ %s : owns", foreignKey.ToTable, table.Name))
+			toTable := strings.ToLower(foreignKey.ToTable)
+			if tableNames.Contains(toTable) {
+				lines = append(lines, fmt.Sprintf("%s ||--o{ %s : owns", toTable, table.Name))
 			}
 		}
 	}


### PR DESCRIPTION
- Added stmt.Close for prepared statements to adapter.go resolve open cursor in oracle
- Updated foreign key compare for ToMermaid and ToERD functions to use lower case compare as it does not work for oracle